### PR TITLE
Add year 2019 to the License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 The ONNX Project
+Copyright (c) 2018 - 2019 The ONNX Project
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Add the year 2019 to the License notice since modifications has been made during 2019.

Following recommandations [here](http://www.gnu.org/licenses/gpl-howto.html) (Section `The copyright notice`).